### PR TITLE
Mapped 'Bet' to 'Promise'

### DIFF
--- a/identifierMappings.js
+++ b/identifierMappings.js
@@ -15,4 +15,5 @@ module.exports = {
     "outOfPocket": "Infinity",
     "PERIODT": "break",
     "based": "toLowerCase",
+    "Bet": "Promise"
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -135,3 +135,12 @@ test(`Should replace yeet with throw`, () => {
   }).code;
   expect(output).toEqual(expected);
 });
+
+test("Should replace Bet with Promise", () => {
+  const input = `new Bet(resolve => resolve("You fr?"));`;
+  const expected = `"use strict";\n\nrequire("core-js/modules/es.promise.js");\nnew Promise(resolve => resolve("You fr?"));`;
+  const output = babel.transform(input, {
+    plugins: [glowupVibes]
+  }).code;
+  expect(output).toEqual(expected);
+});


### PR DESCRIPTION
Added mapping of 'Bet' to 'Promise'
example:
```js
const pinkyPromise = new Bet(resolve => resolve("pinky promise? On god?");
print(pinkyPromise)
```
probably needs a better example in the example.js I'm writing this at 3 AM and was so bored I contributed to open source